### PR TITLE
added le_chiff_ble as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "KiCad/bluetooth_pcb/le_chiff_ble"]
+	path = KiCad/bluetooth_pcb/le_chiff_ble
+	url = git@github.com:MangoIV/le_chiff_ble.git


### PR DESCRIPTION
I added the bluetooth capable le_chiff_ble drop-in replacement PCB for le_chiffre as a git submodule to keep the main repo clean and to not blow it up unnecessarily. 